### PR TITLE
Fixed missing itertools import in recursive.py

### DIFF
--- a/recursive.py
+++ b/recursive.py
@@ -1,4 +1,5 @@
 import argparse
+import itertools
 import numpy as np
 import tensorflow as tf
 import time


### PR DESCRIPTION
Hey, fixed:
```
recursive.py:328:41: F821 undefined name 'itertools'
BREMEN/recursive.py:330:36: F821 undefined name 'itertools'
BREMEN/recursive.py:332:37: F821 undefined name 'itertools'
```
